### PR TITLE
* Dependency Version Updates

### DIFF
--- a/.bitbucket-pipelines/settings.xml
+++ b/.bitbucket-pipelines/settings.xml
@@ -11,7 +11,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-snapshots</name>
-                    <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
@@ -24,7 +24,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-staging</name>
-                    <url>http://oss.sonatype.org/content/groups/staging/</url>
+                    <url>https://oss.sonatype.org/content/groups/staging/</url>
                 </repository>
             </repositories>
         </profile>
@@ -37,7 +37,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-releases</name>
-                    <url>http://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://oss.sonatype.org/content/groups/public/</url>
                 </repository>
             </repositories>
         </profile>

--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.6.3
-MAVEN_SHA=26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5
+MAVEN_VERSION=3.8.1
+MAVEN_SHA=b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -24,7 +24,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-snapshots</name>
-                    <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
@@ -37,7 +37,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-staging</name>
-                    <url>http://oss.sonatype.org/content/groups/staging/</url>
+                    <url>https://oss.sonatype.org/content/groups/staging/</url>
                 </repository>
             </repositories>
         </profile>
@@ -50,7 +50,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-releases</name>
-                    <url>http://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://oss.sonatype.org/content/groups/public/</url>
                 </repository>
             </repositories>
         </profile>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         java_version: [8, 11]
-        maven_version: [3.6.3]
+        maven_version: [3.8.1]
         include:
           - os: ubuntu-20.04
             java_version: 11
-            maven_version: 3.6.3
+            maven_version: 3.8.1
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -84,7 +84,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.6.3_openjdk-11.0.10_zulu-alpine-11.45.27
+        maven_docker_container_image_tag: 3.8.1_openjdk-11.0.10_zulu-alpine-11.45.27
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/.travis-ci/install-maven.sh
+++ b/.travis-ci/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.6.3
-MAVEN_SHA=26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5
+MAVEN_VERSION=3.8.1
+MAVEN_SHA=b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.travis-ci/settings.xml
+++ b/.travis-ci/settings.xml
@@ -24,7 +24,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-snapshots</name>
-                    <url>http://oss.sonatype.org/content/repositories/snapshots/</url>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
@@ -37,7 +37,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-staging</name>
-                    <url>http://oss.sonatype.org/content/groups/staging/</url>
+                    <url>https://oss.sonatype.org/content/groups/staging/</url>
                 </repository>
             </repositories>
         </profile>
@@ -50,7 +50,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>sonatype-releases</name>
-                    <url>http://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://oss.sonatype.org/content/groups/public/</url>
                 </repository>
             </repositories>
         </profile>

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.6.3_openjdk-11.0.10_zulu-alpine-11.45.27
+            image: luminositylabs/maven:3.8.1_openjdk-11.0.10_zulu-alpine-11.45.27
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,9 @@
         <!-- Plugin versioning -->
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
-        <download-maven-plugin.version>1.6.1</download-maven-plugin.version>
+        <download-maven-plugin.version>1.6.2</download-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <git-commit-id-plugin.version>4.0.3</git-commit-id-plugin.version>
+        <git-commit-id-plugin.version>4.0.4</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.0</maven-archetype-plugin.version>
@@ -107,12 +107,12 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>8.41</dependency.checkstyle.version>
+        <dependency.checkstyle.version>8.41.1</dependency.checkstyle.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
-        <dependency.pmd.version>6.32.0</dependency.pmd.version>
+        <dependency.pmd.version>6.33.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.30</dependency.slf4j.version>
         <dependency.spotbugs.version>4.2.2</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>


### PR DESCRIPTION
- Updated download-maven-plugin from v1.6.1 to v1.6.2
- Updated git-commit-id-plugin from v4.0.3 to v4.0.4
- Updated spotbugs-maven-plugin from v4.2.0 to v4.2.2
- Updated checkstyle from v8.41 to v8.41.1
- Updated pmd from v6.32.0 to v6.33.0
- Updated maven from v3.6.3 to v3.8.1
- Updated maven settings.xml files to use https instead of http for repository urls