### PR TITLE
* Dependency Version Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@
         <!-- Plugin versioning -->
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
-        <download-maven-plugin.version>1.6.2</download-maven-plugin.version>
+        <download-maven-plugin.version>1.6.3</download-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <git-commit-id-plugin.version>4.0.4</git-commit-id-plugin.version>
-        <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.0</maven-archetype-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
@@ -98,7 +98,7 @@
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
+        <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
@@ -110,9 +110,9 @@
         <spotbugs-maven-plugin.version>4.2.3</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>8.41.1</dependency.checkstyle.version>
+        <dependency.checkstyle.version>8.42</dependency.checkstyle.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
-        <dependency.pmd.version>6.33.0</dependency.pmd.version>
+        <dependency.pmd.version>6.34.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.30</dependency.slf4j.version>
         <dependency.spotbugs.version>4.2.3</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>


### PR DESCRIPTION
- download-maven-plugin updated from v1.6.2 to v1.6.3
- jacoco-maven-plugin updated from v0.8.6 to v0.8.7
- maven-project-info-reports-plugin updated from v3.1.1 to v3.1.2
- checkstyle updated from v8.41.1 to v8.42
- pmd updated from v6.33.0 to v.34.0