### PR TITLE
* Dependency Version Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
         <download-maven-plugin.version>1.6.3</download-maven-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-        <git-commit-id-plugin.version>4.0.4</git-commit-id-plugin.version>
+        <git-commit-id-plugin.version>4.0.5</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.0</maven-archetype-plugin.version>
@@ -95,7 +95,7 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
@@ -110,9 +110,9 @@
         <spotbugs-maven-plugin.version>4.2.3</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>8.42</dependency.checkstyle.version>
+        <dependency.checkstyle.version>8.43</dependency.checkstyle.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
-        <dependency.pmd.version>6.34.0</dependency.pmd.version>
+        <dependency.pmd.version>6.35.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.30</dependency.slf4j.version>
         <dependency.spotbugs.version>4.2.3</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>


### PR DESCRIPTION
- git-commit-id-plugin updated from v4.0.4 to v4.0.5
- maven-javadoc-plugin updated from v3.2.0 to v3.3.0
- checkstyle updated from v8.42 to v8.43
- pmd updated from v6.34.0 to v.35.0