### PR TITLE
* Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -18,11 +18,5 @@
                 <ignoreVersion type="regex">7\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <!-- Ignore logback version with groovyless suffix -->
-        <rule groupId="ch.qos.logback" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">.*-groovyless</ignoreVersion>
-            </ignoreVersions>
-        </rule>
     </rules>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>8.44</dependency.checkstyle.version>
-        <dependency.logback.version>1.2.4</dependency.logback.version>
+        <dependency.logback.version>1.2.5</dependency.logback.version>
         <dependency.pmd.version>6.36.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
         <dependency.spotbugs.version>4.3.0</dependency.spotbugs.version>


### PR DESCRIPTION
- logback updated from v1.2.4 to v1.2.5
- maven-version-rules.xml updated to remove rule for ignoring logback versions with "-groovyless suffix"