### PR TITLE
Updates

### DIFF
--- a/distributions/payara-full/pom.xml
+++ b/distributions/payara-full/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.luminositylabs.oss.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>payara-full</artifactId>
@@ -15,9 +15,9 @@
     <name>payara-full</name>
 
     <properties>
-        <payara.version>5.2020.6</payara.version>
+        <payara.version>5.2021.5</payara.version>
         <download.url>https://search.maven.org/remotecontent?filepath=fish/payara/distributions/payara/${payara.version}/payara-${payara.version}.zip</download.url>
-        <download.sha1.checksum>609d1df91bf6191620f355f701faed5271b64d63</download.sha1.checksum>
+        <download.sha1.checksum>c0ed3809060d56d20f240066757ed1188e312b6b</download.sha1.checksum>
     </properties>
 
     <build>

--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.1.23-SNAPSHOT</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
 
     <groupId>co.luminositylabs.oss.distributions</groupId>

--- a/testing/nio2-filewalker/pom.xml
+++ b/testing/nio2-filewalker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>testing</artifactId>
         <groupId>co.luminositylabs.oss.testing</groupId>
-        <version>0.0.3</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>nio2-filewalker</artifactId>
@@ -15,7 +15,10 @@
     <name>nio2-filewalker</name>
 
     <properties>
+        <checkstyle.skip>true</checkstyle.skip>
         <maven.test.skip>true</maven.test.skip>
+        <pmd.skip>true</pmd.skip>
+        <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
     <build>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.0.7</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
 
     <groupId>co.luminositylabs.oss.testing</groupId>
     <artifactId>testing</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>testing</name>


### PR DESCRIPTION
- update parent project luminositylabs-oss-parent from v0.1.23-SNAPSHOT to v0.2.2-SNAPSHOT in distributions
  module and submodules
- update parent project luminositylabs-oss-parent from v0.0.7 to v0.2.2-SNAPSHOT in testing module
- update version of testing module from v0.0.3 to v0.0.4-SNAPSHOT
- added properties to nio2-filewalker module to skip checkstyle, pmd, and spotbugs