### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency.logback.version>1.2.5</dependency.logback.version>
         <dependency.pmd.version>6.37.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.3.0</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.4.0</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- spotbugs updated from v4.3.0 to v4.4.0

revert maven from 3.8.2 to 3.8.1