### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,9 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
+        <maven-pmd-plugin.version>3.15.0</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
@@ -106,15 +106,15 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
-        <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
+        <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.3.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.0</dependency.checkstyle.version>
-        <dependency.logback.version>1.2.5</dependency.logback.version>
+        <dependency.logback.version>1.2.6</dependency.logback.version>
         <dependency.pmd.version>6.38.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.4.0</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.4.1</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- maven-javadoc-plugin updated from v3.3.0 to v3.3.1
- maven-pmd-plugin updated from v3.14.0 to v3.15.0
- maven-war-plugin updated from v3.3.1 to v3.3.2
- logback updated from v1.2.5 to v1.2.6
- spotbugs updated from v4.4.0 to v4.4.1