### PR TITLE
Updates

### DIFF
--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.8.1
-MAVEN_SHA=b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02
+MAVEN_VERSION=3.8.3
+MAVEN_SHA=0f1597d11085b8fe93d84652a18c6deea71ece9fabba45a02cf6600c7758fd5b
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
         java_version: [8, 11]
-        maven_version: [3.8.1]
+        maven_version: [3.8.3]
         include:
           - os: ubuntu-20.04
             java_version: 11
-            maven_version: 3.8.1
+            maven_version: 3.8.3
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -84,7 +84,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.1_openjdk-11.0.12_zulu-alpine-11.50.19
+        maven_docker_container_image_tag: 3.8.3_openjdk-11.0.12_zulu-alpine-11.50.19
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.8.1_openjdk-11.0.12_zulu-alpine-11.50.19
+            image: luminositylabs/maven:3.8.3_openjdk-11.0.12_zulu-alpine-11.50.19
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,12 +6,6 @@
         <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- Pin git-commit-id-plugin version to version before terminal V4 release -->
-        <rule groupId="pl.project13.maven" artifactId="git-commit-id-plugin" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">4.9.9</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <!-- Pin testng version to pre-V7 -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -107,14 +107,14 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.4.1</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.4.2</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.0.1</dependency.checkstyle.version>
         <dependency.logback.version>1.2.6</dependency.logback.version>
         <dependency.pmd.version>6.39.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.32</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.4.1</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.4.2</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- spotbugs-maven-plugin updated from v4.4.1 to v4.4.2
- spotbugs updated from v4.4.1 to v4.4.2
- removed outdated git-commit-id-plugin ignore rule in maven-version-rules.xml
- updated CI from maven v3.8.1 to v3.8.3