### PR TITLE
Updates:

### DIFF
--- a/.github/install-maven.sh
+++ b/.github/install-maven.sh
@@ -3,8 +3,8 @@
 set -euf
 
 MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
-MAVEN_VERSION=3.8.4
-MAVEN_SHA=2cdc9c519427bb20fdc25bef5a9063b790e4abd930e7b14b4e9f4863d6f9f13c
+MAVEN_VERSION=3.8.5
+MAVEN_SHA=88e30700f32a3f60e0d28d0f12a3525d29b7c20c72d130153df5b5d6d890c673
 
 sudo apt-get update
 sudo apt-get install -y curl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
         java_version: [8, 11]
-        maven_version: [3.8.4]
+        maven_version: [3.8.5]
         include:
           - os: ubuntu-20.04
             java_version: 11
-            maven_version: 3.8.4
+            maven_version: 3.8.5
             maven_deploy: true
             docker_build: true
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using Zulu ${{ matrix.java_version }}
@@ -84,7 +84,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.4_openjdk-11.0.14.1_zulu-alpine-11.54.25
+        maven_docker_container_image_tag: 3.8.5_openjdk-11.0.14.1_zulu-alpine-11.54.25
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.8.4_openjdk-11.0.14_zulu-alpine-11.54.23
+            image: luminositylabs/maven:3.8.5_openjdk-11.0.14.1_zulu-alpine-11.54.25
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,6 +6,12 @@
         <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- Pin checkstyle version to pre-V10 -->
+        <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">10\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <!-- Pin testng version to pre-V7 -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.10.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.2.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
@@ -98,7 +98,7 @@
         <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.16.0</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.2.1</maven-project-info-reports-plugin.version>
+        <maven-project-info-reports-plugin.version>3.2.2</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
@@ -108,13 +108,13 @@
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.5.3.0</spotbugs-maven-plugin.version>
-        <versions-maven-plugin.version>2.9.0</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.10.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
-        <dependency.logback.version>1.2.10</dependency.logback.version>
-        <dependency.pmd.version>6.42.0</dependency.pmd.version>
+        <dependency.logback.version>1.2.11</dependency.logback.version>
+        <dependency.pmd.version>6.43.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.36</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.5.3</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.6.0</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- updated github actions maven from v3.8.4 to v3.8.5
- updated bitbucket pipelines maven from v3.8.4 to v3.8.5
- updated bitbucket pipelines zulu11 from v11.0.14 to v11.0.14.1
- maven-compiler-plugin updated from v3.10.0 to v3.10.1
- maven-dependency-plugin updated from v3.2.0 to v3.3.0
- maven-project-info-reports-plugin updated from v3.2.1 to v3.2.2
- versions-maven-plugin from v2.9.0 to v2.10.0
- added rule to maven-version-rules.xml to ignore checkstyle v10.x.x
- logback updated from v1.2.10 to v1.2.11
- pmd updated from v6.42.0 to v6.43.0
- spotbugs updated from v4.5.3 to v4.6.0