### PR TITLE
* Updates

### DIFF
--- a/.github/install-zulu8.sh
+++ b/.github/install-zulu8.sh
@@ -4,7 +4,7 @@ set -euf
 
 AZUL_GPG_KEY=0xB1998361219BD9C9
 ZULU_VERSION=8
-ZULU_RELEASE=8.0.342-1
+ZULU_RELEASE=8.0.345-1
 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
 sudo apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'

--- a/pom.xml
+++ b/pom.xml
@@ -100,19 +100,19 @@
         <maven-pmd-plugin.version>3.17.0</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.4.0</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+        <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
-        <maven-site-plugin.version>3.12.0</maven-site-plugin.version>
+        <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.7.1.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.7.1.1</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.11.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
         <dependency.logback.version>1.2.11</dependency.logback.version>
-        <dependency.pmd.version>6.47.0</dependency.pmd.version>
+        <dependency.pmd.version>6.48.0</dependency.pmd.version>
         <dependency.slf4j.version>1.7.36</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.1</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>


### PR DESCRIPTION
- CI zulu-8 updated from v8.0.342-1 to v8.0.345-1
- maven-resources-plugin updated from v3.2.0 to v3.3.0
- maven-site-plugin updated from v3.12.0 to v3.12.1
- spotbugs-maven-plugin updated from v4.7.1.0 to v4.7.1.1
- pmd updated from v6.47.0 to v6.48.0

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>