### PR TITLE
* Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install GPG and generate test key
       run: .github/install-gpg.sh
@@ -42,7 +42,7 @@ jobs:
       run: .github/install-maven.sh
 
     - name: Setup Maven repository cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: m2repo
       with:
@@ -84,7 +84,7 @@ jobs:
       env:
         maven_docker_container_image_repo: luminositylabs
         maven_docker_container_image_name: maven
-        maven_docker_container_image_tag: 3.8.6_openjdk-11.0.17_zulu-alpine-11.60.19
+        maven_docker_container_image_tag: 3.8.6_openjdk-8u352_zulu-alpine-8.66.0.15
         CBD: /usr/src/build
         P: luminositylabs-oss
       run: docker container run --rm -i -v "$(pwd)":"${CBD}" -v ${HOME}/.gnupg:/root/.gnupg -v ${P}-${{ env.maven_docker_container_image_tag }}-mvn-repo:/root/.m2 -w "${CBD}" ${{ env.maven_docker_container_image_repo }}/${{ env.maven_docker_container_image_name }}:${{ env.maven_docker_container_image_tag }} mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} dependency:list-repositories dependency:tree help:active-profiles clean install site site:stage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         maven_version: [3.8.6]
         include:
           - os: ubuntu-22.04
-            java_version: 11
+            java_version: 8
             maven_version: 3.8.6
             maven_deploy: true
             docker_build: true
@@ -73,7 +73,7 @@ jobs:
       run: mvn -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} site site:stage
 
     - name: Maven deploy
-      if: ${{ matrix.maven_deploy && (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request')  }}
+      if: ${{ matrix.maven_deploy && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/jdk8') && (github.event_name != 'pull_request')  }}
       env:
         OSSRHU: ${{ secrets.OSSRHU }}
         OSSRHT: ${{ secrets.OSSRHT }}

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -18,5 +18,11 @@
                 <ignoreVersion type="regex">7\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <!-- Pin logback version to pre-V1.4 -->
+        <rule groupId="ch.qos.logback" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">1\.4\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
     </rules>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <maven-install-plugin.version>3.0.1</maven-install-plugin.version>
+        <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
@@ -111,9 +111,9 @@
         <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
-        <dependency.logback.version>1.2.11</dependency.logback.version>
+        <dependency.logback.version>1.3.5</dependency.logback.version>
         <dependency.pmd.version>6.51.0</dependency.pmd.version>
-        <dependency.slf4j.version>1.7.36</dependency.slf4j.version>
+        <dependency.slf4j.version>2.0.4</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
     </properties>


### PR DESCRIPTION
- github actions workflows updated to use v3 for checkout and cache actions
- docker maven build in github actions workflow modified to use java8 on alpine
- modifications to maven-version-rules.xml to pin logback at 1.3.x for java8 compatibility
- maven-install-plugin updated from v3.0.1 to v3.1.0
- logback updated from v1.2.11 to v1.3.5
- slf4j updated from v1.7.36 to v2.0.4

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>