### PR TITLE
* Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java_version: [8, 11]
+        java_version: [11]
         maven_version: [3.8.6]
         include:
           - os: ubuntu-22.04

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,12 +6,6 @@
         <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- Pin checkstyle version to pre-V10 -->
-        <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">10\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
         <!-- Pin testng version to pre-V7 -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>co.luminositylabs.oss</groupId>
     <artifactId>luminositylabs-oss-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Luminosity Labs Open Source Software Parent</name>
@@ -58,7 +58,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.min.version>1.8</java.min.version>
+        <java.min.version>11</java.min.version>
         <maven.min.version>3.6</maven.min.version>
         <maven.test.skip>false</maven.test.skip>
         <maven.integration.test.skip>false</maven.integration.test.skip>
@@ -110,8 +110,8 @@
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
-        <dependency.logback.version>1.4.4</dependency.logback.version>
+        <dependency.checkstyle.version>10.4</dependency.checkstyle.version>
+        <dependency.logback.version>1.4.5</dependency.logback.version>
         <dependency.pmd.version>6.51.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.4</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>


### PR DESCRIPTION
- github actions main workflow modified to remove java 8
- advanced codeline version from 0.2.6-SNAPSHOT to 0.3.0-SNAPSHOT
- updated maven java.min.version property from 1.8 to 11
- checkstyle updated from v9.3 to 10.4
- logback updated from v1.4.4 to v1.4.5

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>