### PR TITLE
* Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,10 +6,10 @@
         <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- Pin testng version to pre-V7 -->
+        <!-- Pin testng version to pre 7.6.x -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">7\..*</ignoreVersion>
+                <ignoreVersion type="regex">7\.6\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
     </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency.pmd.version>6.52.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.5</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
-        <dependency.testng.version>6.14.3</dependency.testng.version>
+        <dependency.testng.version>7.5</dependency.testng.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- testng updated from v6.14.3 to v7.5
- added rule to maven-version-rules.xml to ignore testng 7.6.x

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>