### PR TITLE
- modified rule in maven-version-rules.xml to ignore testng 7.7.0

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -9,7 +9,7 @@
         <!-- Pin testng version to pre 7.6.x -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">7\.6\..*</ignoreVersion>
+                 <ignoreVersion type="regex">7\.[6-9]\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
     </rules>


### PR DESCRIPTION
Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>