### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,19 +6,19 @@
         <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- Pin checkstyle version to pre-V10 -->
+        <!-- Pin checkstyle version to pre-v10 (v10 is requires Java11) -->
         <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">10\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <!-- Pin testng version to pre-V7 -->
+        <!-- Pin testng version to 7.5.x (v7.6+ requires Java11) -->
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">7\..*</ignoreVersion>
+                <ignoreVersion type="regex">7\.[6-9].*</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <!-- Pin logback version to pre-V1.4 -->
+        <!-- Pin logback version to v1.3.x (v1.4.0+ requires Java11) -->
         <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">1\.4\..*</ignoreVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -108,14 +108,14 @@
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
-        <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.14.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
         <dependency.logback.version>1.3.5</dependency.logback.version>
         <dependency.pmd.version>6.52.0</dependency.pmd.version>
-        <dependency.slf4j.version>2.0.5</dependency.slf4j.version>
+        <dependency.slf4j.version>2.0.6</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
-        <dependency.testng.version>6.14.3</dependency.testng.version>
+        <dependency.testng.version>7.5</dependency.testng.version>
     </properties>
 
     <dependencyManagement>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.luminositylabs.oss</groupId>
         <artifactId>luminositylabs-oss-parent</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.2.6-SNAPSHOT</version>
     </parent>
 
     <groupId>co.luminositylabs.oss.testing</groupId>


### PR DESCRIPTION
- updated versions-maven-plugin from v2.13.0 to v2.14.0
- updated slf4j from v2.0.5 to v2.0.6
- updated testng from v6.14.3 to v7.5
- synced parent project version in testing module with version for top level project
- modified rules in maven-version-rules.xml to ignore checkstyle v10+, testng v7.6+, and logback v1.4+

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>