### PR TITLE
Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,18 +11,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        jdk_version: [8.0.352-zulu, 11.0.17-zulu, 17.0.5-zulu, 19.0.1-zulu]
+        jdk_version: [8.0.362-zulu, 11.0.18-zulu, 17.0.6-zulu, 19.0.2-zulu]
         maven_version: [3.8.7]
         include:
           - os: ubuntu-22.04
-            jdk_version: 8.0.352-zulu
-            zulu_version: 8.66.0.15
+            jdk_version: 8.0.362-zulu
+            zulu_version: 8.68.0.19
             maven_version: 3.8.7
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.8.7_openjdk-8u352_zulu-alpine-8.66.0.15
+            maven_docker_container_image_tag: 3.8.7_openjdk-8u362_zulu-alpine-8.68.0.19
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,10 @@
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
         <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
-        <maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.4.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
@@ -97,8 +97,8 @@
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
         <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>3.19.0</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.4.1</maven-project-info-reports-plugin.version>
+        <maven-pmd-plugin.version>3.20.0</maven-pmd-plugin.version>
+        <maven-project-info-reports-plugin.version>3.4.2</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
@@ -112,10 +112,10 @@
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
         <dependency.logback.version>1.3.5</dependency.logback.version>
-        <dependency.pmd.version>6.53.0</dependency.pmd.version>
+        <dependency.pmd.version>6.54.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.6</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
-        <dependency.testng.version>7.5</dependency.testng.version>
+        <dependency.testng.version>7.7.1</dependency.testng.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- updated CI to latest zulu versions (8.0.362, 11.0.18, 17.0.6, 19.0.2)
- removed extraneous environment variables from docker maven CI build
- updated maven-checkstyle-plugin from v3.2.0 to v3.2.1
- updated maven-dependency-plugin from v3.4.0 to v3.5.0
- updated maven-pmd-plugin from v3.19.0 to v3.20.0
- updated maven-project-info-reports-plugin from v3.4.1 ro v3.4.2
- updated pmd from 6.53.0 to v6.54.0

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>

(cherry picked from commit a591c3c4199d96967505d09a246047bda24e5fd8)
Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>