### PR TITLE
Updates

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,7 @@
 pipelines:
     default:
         - step:
-            image: luminositylabs/maven:3.8.6_openjdk-11.0.17_zulu-alpine-11.60.19
+            image: luminositylabs/maven:3.8.7_openjdk-8u362_zulu-alpine-8.68.0.19
             script:
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:list-repositories
                 - mvn -U -V -s .bitbucket-pipelines/settings.xml -Psonatype-snapshots,sonatype-staging,sonatype-releases dependency:tree

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
-        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.0</maven-install-plugin.version>


### PR DESCRIPTION
- updated bitbucket pipelines to use latest zulu-11 version (3.8.7_openjdk-8u362_zulu-alpine-8.68.0.19)
- updated maven-enforcer-plugin from v3.1.0 to v3.2.1

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>

(cherry picked from commit 3d24bc9a31d211ad4f1ed0319bb9175b3e2609f0)
Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>