### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
@@ -104,16 +104,16 @@
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.0.0</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.7.3.2</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>10.8.1</dependency.checkstyle.version>
-        <dependency.logback.version>1.4.5</dependency.logback.version>
+        <dependency.checkstyle.version>10.9.1</dependency.checkstyle.version>
+        <dependency.logback.version>1.4.6</dependency.logback.version>
         <dependency.pmd.version>6.55.0</dependency.pmd.version>
-        <dependency.slf4j.version>2.0.6</dependency.slf4j.version>
+        <dependency.slf4j.version>2.0.7</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
         <dependency.testng.version>7.7.1</dependency.testng.version>
     </properties>


### PR DESCRIPTION
- maven-failsafe-plugin updated from v2.22.2 to v3.0.0
- maven-surefire-plugin updated from v2.22.2 to v3.0.0
- maven-surefire-report-plugin updated from v2.22.2 to v3.0.0
- checkstyle updated from v10.8.1 to v10.9.1
- logback updated from v1.4.5 to v1.4.6
- slf4j updated from v2.0.6 to v2.0.7