### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <!-- Plugin versioning -->
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
-        <download-maven-plugin.version>1.6.8</download-maven-plugin.version>
+        <download-maven-plugin.version>1.7.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
@@ -90,8 +90,8 @@
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
-        <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+        <maven-failsafe-plugin.version>3.1.0</maven-failsafe-plugin.version>
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
@@ -104,8 +104,8 @@
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.0.0</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.1.0</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.7.3.4</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
@@ -115,7 +115,7 @@
         <dependency.pmd.version>6.55.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.7</dependency.slf4j.version>
         <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
-        <dependency.testng.version>7.7.1</dependency.testng.version>
+        <dependency.testng.version>7.8.0</dependency.testng.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- download-maven-plugin updated from v1.6.8 to v1.7.0
- maven-failsafe-plugin updated from v3.0.0 to v3.1.0
- maven-gpg-plugin updated from v3.0.1 to v3.1.0
- maven-surefire-plugin updated from v3.0.0 to v3.1.0
- maven-surefire-report-plugin updated from v3.0.0 to v3.1.0
- testng updated from v7.5 to v7.5.1