### PR TITLE
Multi-module linting plugin config 

### DIFF
--- a/testing/nio2-filewalker/pom.xml
+++ b/testing/nio2-filewalker/pom.xml
@@ -15,10 +15,7 @@
     <name>nio2-filewalker</name>
 
     <properties>
-        <checkstyle.skip>true</checkstyle.skip>
         <maven.test.skip>true</maven.test.skip>
-        <pmd.skip>true</pmd.skip>
-        <spotbugs.skip>true</spotbugs.skip>
     </properties>
 
     <build>

--- a/testing/nio2-filewalker/src/main/java/co/luminositylabs/oss/testing/nio2/FileWalker.java
+++ b/testing/nio2-filewalker/src/main/java/co/luminositylabs/oss/testing/nio2/FileWalker.java
@@ -8,6 +8,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -69,7 +70,7 @@ public class FileWalker extends SimpleFileVisitor<Path> {
 
 
     /**
-     * Set the file file count.
+     * Set the file count.
      *
      * @param fileCount the file count.
      */
@@ -164,7 +165,7 @@ public class FileWalker extends SimpleFileVisitor<Path> {
      * @return the directory skip list
      */
     public List<String> getSkipDirectories() {
-        return skipDirectories;
+        return Collections.unmodifiableList(skipDirectories);
     }
 
 
@@ -174,7 +175,7 @@ public class FileWalker extends SimpleFileVisitor<Path> {
      * @param skipDirectories the directory skip list
      */
     public void setSkipDirectories(final List<String> skipDirectories) {
-        this.skipDirectories = skipDirectories;
+        this.skipDirectories = List.copyOf(skipDirectories);
     }
 
 
@@ -210,7 +211,7 @@ public class FileWalker extends SimpleFileVisitor<Path> {
         FileVisitResult fileVisitResult = FileVisitResult.CONTINUE;
         if (!isExcluded(path)) {
             fileCount++;
-            if ((fileCountCutoff != -1) && (fileCount > fileCountCutoff)) {
+            if (fileCountCutoff != -1 && fileCount > fileCountCutoff) {
                 fileVisitResult = FileVisitResult.TERMINATE;
             }
         }
@@ -228,7 +229,7 @@ public class FileWalker extends SimpleFileVisitor<Path> {
     public FileVisitResult visitFileFailed(final Path path,
                                            final IOException exc) throws IOException {
         errorCount++;
-        if ((errorCount % ERROR_COUNT_REPORTING_CHECKPOINT) == 0) {
+        if (errorCount % ERROR_COUNT_REPORTING_CHECKPOINT == 0) {
             logger.debug("currentErrorCount: {}", errorCount);
         }
         logger.error("Failed to visit path: {} ({}) ({})", path, exc.getClass().getName(), exc.getMessage());

--- a/testing/nio2-filewalker/src/test/java/co/luminositylabs/oss/testing/nio2/FileWalkTest.java
+++ b/testing/nio2-filewalker/src/test/java/co/luminositylabs/oss/testing/nio2/FileWalkTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -54,7 +55,20 @@ public class FileWalkTest {
         Path exclusionsListPath = Paths.get(
                 directoryScanExclusionsListURL.toURI()
         );
-        List<String> exclusionsList = Files.readAllLines(exclusionsListPath);
+        List<String> exclusionsList = Files.readAllLines(exclusionsListPath)
+                .stream()
+                .map(s -> {
+                    String replacementString = s;
+                    for (String propertyName : System.getProperties().stringPropertyNames()) {
+                        String propertyValue = System.getProperty(propertyName);
+                        String replacementExpression = "${" + propertyName + "}";
+                        if (replacementString.contains(replacementExpression)) {
+                            replacementString = replacementString.replace(replacementExpression, propertyValue);
+                        }
+                    }
+                    return replacementString;
+                })
+                .collect(Collectors.toList());
 
         URL directoryScanInclusionsListURL = Thread.currentThread()
                 .getContextClassLoader()
@@ -63,7 +77,20 @@ public class FileWalkTest {
         Path inclusionsListPath = Paths.get(
                 directoryScanInclusionsListURL.toURI()
         );
-        List<String> inclusionsList = Files.readAllLines(inclusionsListPath);
+        List<String> inclusionsList = Files.readAllLines(inclusionsListPath)
+                .stream()
+                .map(s -> {
+                    String replacementString = s;
+                    for (String propertyName : System.getProperties().stringPropertyNames()) {
+                        String propertyValue = System.getProperty(propertyName);
+                        String replacementExpression = "${" + propertyName + "}";
+                        if (replacementString.contains(replacementExpression)) {
+                            replacementString = replacementString.replace(replacementExpression, propertyValue);
+                        }
+                    }
+                    return replacementString;
+                })
+                .collect(Collectors.toList());
 
         EnumSet<FileVisitOption> options = EnumSet.noneOf(FileVisitOption.class);
         int maxDepth = Integer.MAX_VALUE;
@@ -93,7 +120,7 @@ public class FileWalkTest {
                 totalDirectoryCount += fileIndexer.getDirectoryCount();
                 totalErrors += fileIndexer.getErrorCount();
             } else {
-                logger.error("Skipping {} (non-existant?)", inclusion);
+                logger.error("Skipping {} (non-existent?)", inclusion);
             }
         }
 

--- a/testing/nio2-filewalker/src/test/resources/directoryScanExclusions.lst
+++ b/testing/nio2-filewalker/src/test/resources/directoryScanExclusions.lst
@@ -2,3 +2,4 @@
 /net
 /proc
 /sys
+${user.home}/Library

--- a/testing/nio2-filewalker/src/test/resources/directoryScanInclusions.lst
+++ b/testing/nio2-filewalker/src/test/resources/directoryScanInclusions.lst
@@ -1,1 +1,2 @@
-/
+${basedir}
+${user.home}

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -24,6 +24,15 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <configuration>
+                        <rulesets>
+                            <ruleset>file:///${multi.module.root}/pmd.xml</ruleset>
+                        </rulesets>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <configuration>


### PR DESCRIPTION
- modifications to testing module to configure PMD plugin for multi-module projects
- enabled checkstyle and spotbugs in file walker test module
- fixed checkstyle, pmd, and spotbugs warning/errors in file walker test module
- modified file walker test to do system property replacement in inclusion/exclusion lists