### PR TITLE
Updates

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -6,6 +6,12 @@
         <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- ignore maven-dependency-plugin v3.6.0 due to bug in list-repositories goal -->
+        <rule groupId="org.apache.maven.plugins" artifactId="maven-dependency-plugin" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">3.6.0</ignoreVersion>
+            </ignoreVersions>
+        </rule>
         <!-- ignore release client version of pmd dependency -->
         <rule groupId="net.sourceforge.pmd" comparisonMethod="maven">
             <ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-        <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
@@ -103,14 +103,14 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>3.1.0</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.7.3.4</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>10.11.0</dependency.checkstyle.version>
+        <dependency.checkstyle.version>10.12.0</dependency.checkstyle.version>
         <dependency.logback.version>1.4.7</dependency.logback.version>
         <dependency.pmd.version>6.55.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.7</dependency.slf4j.version>


### PR DESCRIPTION
- maven-checkstyle-plugin updated from v3.2.2 to v3.3.o
- maven-source-plugin updated from v3.2.1 to v3.3.0
- checkstyle updated from v10.11.0 to v10.12.0
- maven-version-rules.xml updated to ignore maven-dependency-plugin v3.6.0