### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,12 @@
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.2.1</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.2.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.3.1</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.4.5</maven-project-info-reports-plugin.version>
@@ -104,17 +104,17 @@
         <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.2.1</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.2.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.7.3.6</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.8.1.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.16.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>10.12.4</dependency.checkstyle.version>
         <dependency.logback.version>1.4.11</dependency.logback.version>
         <dependency.pmd.version>6.55.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.9</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.8.0</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.8.1</dependency.spotbugs.version>
         <dependency.testng.version>7.8.0</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- maven-failsafe-plugin updated from v3.2.1 to v3.2.2
- maven-javadoc-plugin updated from 3.6.0 to 3.6.2
- maven-surefire-plugin updated from 3.2.1 to v3.2.2
- maven-surefire-report-plugin updated from v3.2.1 to v3.2.2
- spotbugs-maven-plugin updated from v4.7.3.6 to v4.8.1.0
- spotbugs updated from v4.8.0 to v4.8.1