### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <pmd.skip>false</pmd.skip>
         <spotbugs.skip>false</spotbugs.skip>
         <!-- Plugin versioning -->
-        <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <download-maven-plugin.version>1.7.1</download-maven-plugin.version>
         <exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
@@ -95,7 +95,7 @@
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.3.1</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
@@ -107,14 +107,14 @@
         <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>3.2.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.8.1.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>10.12.5</dependency.checkstyle.version>
-        <dependency.logback.version>1.4.11</dependency.logback.version>
+        <dependency.logback.version>1.4.14</dependency.logback.version>
         <dependency.pmd.version>6.55.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.9</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.8.1</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.8.2</dependency.spotbugs.version>
         <dependency.testng.version>7.8.0</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- build-helper-maven-plugin updated from v3.4.0 to v3.5.0
- maven-javadoc-plugin updated from v3.6.2 to v3.6.3
- spotbugs-maven-plugin updated from v4.8.1.0 to v4.8.2.0
- logback updated from v1.4.11 to v1.4.14
- spotbugs updated from v4.8.1 to v4.8.2