### PR TITLE
revert maven-compiler-plugin back to v3.11.0 from v3.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,11 @@
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.12.0</maven-compiler-plugin.version>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <!-- revert back to v3.11.0 due to https://issues.apache.org/jira/browse/MCOMPILER-567 -->
+        <!--<maven-compiler-plugin.version>3.12.0</maven-compiler-plugin.version>-->
+
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>


### PR DESCRIPTION
 due to https://issues.apache.org/jira/browse/MCOMPILER-567