### PR TITLE
add maven-compiler-plugin v3.12.0 to ignore rules in maven-version-rules.xml due to https://issues.apache.org/jira/browse/MCOMPILER-567

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -4,5 +4,12 @@
     <ignoreVersions>
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
-    <rules/>
+    <rules>
+        <!-- ignore maven-compiler-plugin v3.12.0 due to bug: https://issues.apache.org/jira/browse/MCOMPILER-567 -->
+        <rule groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">3.12.0</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+    </rules>
 </ruleset>


### PR DESCRIPTION
add maven-compiler-plugin v3.12.0 to ignore rules in maven-version-rules.xml due to https://issues.apache.org/jira/browse/MCOMPILER-567