### PR TITLE
mitigate https://issues.apache.org/jira/browse/MCOMPILER-567

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -5,6 +5,13 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
+        <!-- ignore maven-compiler-plugin v3.12.0 due to bug: https://issues.apache.org/jira/browse/MCOMPILER-567 -->
+        <rule groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">3.12.0</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+
         <!-- Pin checkstyle version to pre-v10 (v10 is requires Java11) -->
         <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
             <ignoreVersions>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,11 @@
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.12.0</maven-compiler-plugin.version>
+
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <!-- revert back to v3.11.0 due to https://issues.apache.org/jira/browse/MCOMPILER-567 -->
+        <!--<maven-compiler-plugin.version>3.12.0</maven-compiler-plugin.version>-->
+
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>


### PR DESCRIPTION
- revert maven-compiler-plugin back to v3.11.0 from v3.12.0 due to https://issues.apache.org/jira/browse/MCOMPILER-567 (#216)
- add maven-compiler-plugin v3.12.0 to ignore rules in maven-version-rules.xml due to https://issues.apache.org/jira/browse/MCOMPILER-567 (#217)