### PR TITLE
Testing modules

### DIFF
--- a/testing/maven-version-rules.xml
+++ b/testing/maven-version-rules.xml
@@ -1,9 +1,8 @@
 <ruleset comparisonMethod="maven"
-         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
     <ignoreVersions>
-        <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
+        <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
         <!-- Pin checkstyle version to pre-v10 (v10 is requires Java11) -->
@@ -21,13 +20,7 @@
         <!-- Pin logback version to v1.3.x (v1.4.0+ requires Java11) -->
         <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.4\..*</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <!-- ignore release client version of pmd dependency -->
-        <rule groupId="net.sourceforge.pmd" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">\d\.\d\.\d-rc\d</ignoreVersion>
+                <ignoreVersion type="regex">1\.[4-9]\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
     </rules>


### PR DESCRIPTION
- update header for maven-version-rules.xml to latest namespace
- add release client (RC) release versions to ignore pattern in maven-version-rules.xml
- update logback exclusion rule for versions greater than v1.4.x