### PR TITLE
maven versions rules

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -5,11 +5,5 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- ignore maven-compiler-plugin v3.12.0 due to bug: https://issues.apache.org/jira/browse/MCOMPILER-567 -->
-        <rule groupId="org.apache.maven.plugins" artifactId="maven-compiler-plugin" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">3.12.0</ignoreVersion>
-            </ignoreVersions>
-        </rule>
     </rules>
 </ruleset>

--- a/testing/maven-version-rules.xml
+++ b/testing/maven-version-rules.xml
@@ -1,16 +1,9 @@
 <ruleset comparisonMethod="maven"
-         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://www.mojohaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+         xmlns="https://www.mojohaus.org/VERSIONS/RULE/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://www.mojohaus.org/VERSIONS/RULE/2.1.0 https://www.mojohaus.org/versions/versions-model/xsd/rule-2.1.0.xsd">
     <ignoreVersions>
-        <ignoreVersion type="regex">.*-[M|alpha|beta].*</ignoreVersion>
+        <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- ignore release client version of pmd dependency -->
-        <rule groupId="net.sourceforge.pmd" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">\d\.\d\.\d-rc\d</ignoreVersion>
-            </ignoreVersions>
-        </rule>
     </rules>
 </ruleset>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>testing</artifactId>
     <packaging>pom</packaging>
 
-    <name>testing</name>
+    <name>Luminosity Labs Open Source Software - Testing</name>
     <description>Test code aggregator module</description>
 
     <modules>


### PR DESCRIPTION
- remove outdated ignore rules in maven-version-rules.xml for maven-compiler-plugin and pmd
- update header for maven-version-rules.xml to latest namespace in testing module project
- add release client (RC) release versions to ignore pattern in maven-version-rules.xml in testing module project