### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,21 +78,21 @@
         <directory-maven-plugin-hazendaz.version>1.1.1</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.8.1</download-maven-plugin.version>
         <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
-        <git-commit-id-maven-plugin.version>8.0.1</git-commit-id-maven-plugin.version>
+        <git-commit-id-maven-plugin.version>8.0.2</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
-        <maven-assembly-plugin.version>3.7.0</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
-        <maven-gpg-plugin.version>3.2.0</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.1</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
@@ -111,7 +111,7 @@
         <spotbugs-maven-plugin.version>4.8.3.1</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>10.14.1</dependency.checkstyle.version>
+        <dependency.checkstyle.version>10.14.2</dependency.checkstyle.version>
         <dependency.logback.version>1.5.3</dependency.logback.version>
         <dependency.pmd.version>6.55.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.12</dependency.slf4j.version>
@@ -121,6 +121,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${dependency.logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${dependency.logback.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
@@ -143,7 +153,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${dependency.logback.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
- git-commit-id-maven-plugin updated from v8.0.1 to v8.0.2
- maven-assembly-plugin updated from v3.7.0 to v3.7.1
- maven-compiler-plugin updated from v3.12.1 to v3.13.0
- maven-gpg-plugin updated from v3.2.0 to v3.2.1
- checkstyle updated from v10.14.1 to v10.14.2
- added logback classic and core dependency declarations to dependency management section