### PR TITLE
remove redundant directory-maven-plugin declaration from plugin management section of top-level pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,11 +576,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.github.hazendaz.maven</groupId>
-                    <artifactId>directory-maven-plugin</artifactId>
-                    <version>${directory-maven-plugin-hazendaz.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco-maven-plugin.version}</version>


### PR DESCRIPTION
remove redundant directory-maven-plugin declaration from plugin management section of top-level pom.xml