### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.3.2</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
+        <maven-pmd-plugin.version>3.22.0</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
@@ -113,7 +113,7 @@
         <!-- Dependency versions -->
         <dependency.checkstyle.version>10.15.0</dependency.checkstyle.version>
         <dependency.logback.version>1.5.6</dependency.logback.version>
-        <dependency.pmd.version>7.0.0</dependency.pmd.version>
+        <dependency.pmd.version>7.1.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.13</dependency.slf4j.version>
         <dependency.spotbugs.version>4.8.4</dependency.spotbugs.version>
         <dependency.testng.version>7.10.1</dependency.testng.version>
@@ -434,11 +434,6 @@
                     <dependencies>
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-compat6</artifactId>
-                            <version>${dependency.pmd.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-core</artifactId>
                             <version>${dependency.pmd.version}</version>
                         </dependency>
@@ -562,15 +557,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${versions-maven-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>check-parent-versions-update</id>
-                            <goals>
-                                <goal>display-parent-updates</goal>
-                            </goals>
-                            <phase>validate</phase>
-                        </execution>
-                    </executions>
                     <configuration>
                         <rulesUri>file:///${project.basedir}/maven-version-rules.xml</rulesUri>
                     </configuration>
@@ -772,14 +758,12 @@
                             <execution>
                                 <id>check-versions</id>
                                 <goals>
+                                    <goal>display-parent-updates</goal>
                                     <goal>display-plugin-updates</goal>
                                     <goal>display-dependency-updates</goal>
                                     <goal>display-property-updates</goal>
                                 </goals>
                                 <phase>validate</phase>
-                                <configuration>
-                                    <rulesUri>file:///${project.basedir}/maven-version-rules.xml</rulesUri>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -710,12 +710,16 @@
                     <reportSet>
                         <id>version-update-reports</id>
                         <reports>
+                            <report>display-parent-updates</report>
                             <report>dependency-updates-report</report>
                             <report>plugin-updates-report</report>
                             <report>property-updates-report</report>
                         </reports>
                     </reportSet>
                 </reportSets>
+                <configuration>
+                    <rulesUri>file:///${project.basedir}/maven-version-rules.xml</rulesUri>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -77,6 +77,19 @@
         </plugins>
     </build>
 
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <rulesUri>file:///${multi.module.root}/maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
     <profiles>
         <profile>
             <id>check-versions</id>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -33,14 +33,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>versions-maven-plugin</artifactId>
-                    <configuration>
-                        <!--suppress UnresolvedMavenProperty -->
-                        <rulesUri>file:///${multi.module.root}/maven-version-rules.xml</rulesUri>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>com.github.hazendaz.maven</groupId>
                     <artifactId>directory-maven-plugin</artifactId>
                     <executions>
@@ -97,17 +89,18 @@
                             <execution>
                                 <id>check-versions</id>
                                 <goals>
+                                    <goal>display-parent-updates</goal>
                                     <goal>display-plugin-updates</goal>
                                     <goal>display-dependency-updates</goal>
                                     <goal>display-property-updates</goal>
                                 </goals>
                                 <phase>validate</phase>
-                                <configuration>
-                                    <!--suppress UnresolvedMavenProperty -->
-                                    <rulesUri>file:///${multi.module.root}/maven-version-rules.xml</rulesUri>
-                                </configuration>
                             </execution>
                         </executions>
+                        <configuration>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <rulesUri>file:///${multi.module.root}/maven-version-rules.xml</rulesUri>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
- maven-pmd-plugin updated from v3.21.2 to v3.22.0
- pmd updated from v7.0.0 to v7.1.0
- moved display-parent-updates goal of versions-maven-plugin to check-versions maven profile
- removed redundant config for versions-maven-plugin from check-versions maven profile