### PR TITLE
Project configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -679,9 +679,6 @@
                         <id>pmd</id>
                         <configuration>
                             <skip>false</skip>
-                            <rulesets>
-                                <ruleset>pmd.xml</ruleset>
-                            </rulesets>
                         </configuration>
                         <reports>
                             <report>pmd</report>
@@ -689,6 +686,11 @@
                         </reports>
                     </reportSet>
                 </reportSets>
+                <configuration>
+                    <rulesets>
+                        <ruleset>pmd.xml</ruleset>
+                    </rulesets>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -80,6 +80,16 @@
     <reporting>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <configuration>
+                    <rulesets>
+                        <!--suppress UnresolvedMavenProperty -->
+                        <ruleset>file:///${multi.module.root}/pmd.xml</ruleset>
+                    </rulesets>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
- moved maven-pmd-plugin ruleset config out of report set specific config and into higher level reporting plugin config