### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <directory-maven-plugin-hazendaz.version>1.1.3</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.9.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
-        <git-commit-id-maven-plugin.version>9.0.0</git-commit-id-maven-plugin.version>
+        <git-commit-id-maven-plugin.version>9.0.1</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>


### PR DESCRIPTION
- git-commit-id-maven-plugin updated from v9.0.0 to v9.0.1