### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <directory-maven-plugin-hazendaz.version>1.2.0</directory-maven-plugin-hazendaz.version>
-        <download-maven-plugin.version>1.10.0</download-maven-plugin.version>
+        <download-maven-plugin.version>1.11.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
         <git-commit-id-maven-plugin.version>9.0.1</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
@@ -91,7 +91,7 @@
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
@@ -105,14 +105,14 @@
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.5.0</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.5.1</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <spotbugs-maven-plugin.version>4.8.6.4</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>10.18.2</dependency.checkstyle.version>
-        <dependency.logback.version>1.5.8</dependency.logback.version>
+        <dependency.logback.version>1.5.11</dependency.logback.version>
         <dependency.pmd.version>7.6.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
         <dependency.spotbugs.version>4.8.6</dependency.spotbugs.version>


### PR DESCRIPTION
- download-maven-plugin updated from v1.10.0 to v1.11.0
- maven-failsafe-plugin updated from v3.5.0 to v3.5.1
- maven-surefire-plugin updated from v3.5.0 to v3.5.1
- maven-surefire-report-plugin updated from v3.5.0 to v3.5.1
- logback updated from v1.5.8 to v1.5.11