### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,44 +76,44 @@
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <directory-maven-plugin-hazendaz.version>1.2.0</directory-maven-plugin-hazendaz.version>
-        <download-maven-plugin.version>1.11.0</download-maven-plugin.version>
-        <exec-maven-plugin.version>3.4.1</exec-maven-plugin.version>
+        <download-maven-plugin.version>1.11.2</download-maven-plugin.version>
+        <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
         <git-commit-id-maven-plugin.version>9.0.1</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-        <maven-archetype-plugin.version>3.3.0</maven-archetype-plugin.version>
+        <maven-archetype-plugin.version>3.3.1</maven-archetype-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
-        <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.1.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
-        <maven-jxr-plugin.version>3.5.0</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>3.25.0</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.7.0</maven-project-info-reports-plugin.version>
+        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
+        <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
+        <maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
+        <maven-project-info-reports-plugin.version>3.8.0</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
-        <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
+        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.5.1</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.5.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.8.6.4</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>10.18.2</dependency.checkstyle.version>
-        <dependency.logback.version>1.5.11</dependency.logback.version>
-        <dependency.pmd.version>7.6.0</dependency.pmd.version>
+        <dependency.checkstyle.version>10.20.1</dependency.checkstyle.version>
+        <dependency.logback.version>1.5.12</dependency.logback.version>
+        <dependency.pmd.version>7.7.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
         <dependency.spotbugs.version>4.8.6</dependency.spotbugs.version>
         <dependency.testng.version>7.10.2</dependency.testng.version>


### PR DESCRIPTION
- download-maven-plugin updated from v1.11.0 to v1.11.2
- exec-maven-plugin updated from v3.4.1 to v3.5.0
- maven-archetype-plugin updated from v3.3.0 to v3.3.1
- maven-checkstyle-plugin updated from v3.5.0 to v3.6.0
- maven-dependency-plugin updated from v3.8.0 to v3.8.1
- maven-failsafe-plugin updated from v3.5.1 to v3.5.2
- maven-javadoc-plugin updated from v3.10.1 to v3.11.1
- maven-jxr-plugin updated from v3.5.0 to v3.6.0
- maven-pmd-plugin updated from v3.25.0 to v3.26.0
- maven-project-info-reports-plugin updated from v3.7.0 to v3.8.0
- maven-site-plugin updated from v3.20.0 to v3.21.0
- maven-surefire-plugin updated from v3.5.1 to v3.5.2
- maven-surefire-report-plugin updated from v3.5.1 to v3.5.2
- spotbugs-maven-plugin updated from v4.8.6.4 to v4.8.6.6
- checkstyle updated from v10.18.2 to v10.20.1
- logback updated from v1.5.11 to v1.5.12
- pmd updated from v7.6.0 to v7.7.0