### PR TITLE
Maven Config

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Djavadoc.path=${SDKMAN_DIR}/candidates/java/8.0.432-zulu/bin/javadoc


### PR DESCRIPTION
- add maven.conf to include specific javadoc path to java8 javadoc