### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,21 +85,21 @@
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.4.1</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
+        <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.1.0</maven-jarsigner-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.6.0</maven-jxr-plugin.version>
         <maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.8.0</maven-project-info-reports-plugin.version>
+        <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
@@ -112,11 +112,11 @@
         <spotbugs-maven-plugin.version>4.9.1.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>10.21.2</dependency.checkstyle.version>
-        <dependency.logback.version>1.5.16</dependency.logback.version>
-        <dependency.pmd.version>7.10.0</dependency.pmd.version>
-        <dependency.slf4j.version>2.0.16</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.9.1</dependency.spotbugs.version>
+        <dependency.checkstyle.version>10.21.3</dependency.checkstyle.version>
+        <dependency.logback.version>1.5.17</dependency.logback.version>
+        <dependency.pmd.version>7.11.0</dependency.pmd.version>
+        <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
+        <dependency.spotbugs.version>4.9.2</dependency.spotbugs.version>
         <dependency.testng.version>7.11.0</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- maven-compiler-plugin updated from v3.13.0 to v3.14.0
- maven-deploy-plugin updated from v3.1.3 to v3.1.4
- maven-install-plugin updated from v3.1.3 to v3.1.4
- maven-project-info-reports-plugin updated from v3.8.0 to v3.9.0
- checkstyle updated from v10.21.2 to v10.21.3
- logback updated from v1.5.16 to v1.5.17
- pmd updated from v7.10.0 to v7.11.0
- slf4j updated from v2.0.16 to v2.0.17
- spotbugs updated from v4.9.1 to v4.9.2