### PR TITLE
Jdk11 maintenance - Updates (#489)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <pmd.skip>false</pmd.skip>
         <spotbugs.skip>false</spotbugs.skip>
         <!-- Plugin versioning -->
-        <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <directory-maven-plugin-hazendaz.version>1.2.1</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>


### PR DESCRIPTION
- build-helper-maven-plugin updated from v3.6.0 to v3.6.1


(cherry picked from commit 188f7bd45f765f2c9bc8361e80cbd70eb4104a5a)