### PR TITLE
Sonatype Central Portal Publishing

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -3,9 +3,9 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.OSSRHU}</username>
-            <password>${env.OSSRHT}</password>
+            <id>sonatype-central-portal</id>
+            <username>${env.SONATYPE_CENTRAL_PORTAL_REPO_USERNAME}</username>
+            <password>${env.SONATYPE_CENTRAL_PORTAL_REPO_PASSWORD}</password>
         </server>
     </servers>
     <profiles>
@@ -16,44 +16,17 @@
             </properties>
         </profile>
         <profile>
-            <id>sonatype-snapshots</id>
+            <id>sonatype-central-snapshots</id>
             <repositories>
                 <repository>
-                    <id>sonatype-snapshots</id>
+                    <id>sonatype-central-snapshots</id>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
-                    <name>sonatype-snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                </repository>
-            </repositories>
-        </profile>
-        <profile>
-            <id>sonatype-staging</id>
-            <repositories>
-                <repository>
-                    <id>sonatype-staging</id>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <name>sonatype-staging</name>
-                    <url>https://oss.sonatype.org/content/groups/staging/</url>
-                </repository>
-            </repositories>
-        </profile>
-        <profile>
-            <id>sonatype-releases</id>
-            <repositories>
-                <repository>
-                    <id>sonatype-releases</id>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                    <name>sonatype-releases</name>
-                    <url>https://oss.sonatype.org/content/groups/public/</url>
+                    <name>sonatype-central-snapshots</name>
+                    <url>https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/snapshots/</url>
                 </repository>
             </repositories>
         </profile>
     </profiles>
-
 </settings>

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       MAVEN_PROPS: -Djavadoc.path=`which javadoc`
-      PROFILES: gpg,release-sign-artifacts,sonatype-deployment,sonatype-snapshots,sonatype-staging,sonatype-releases
+      PROFILES: gpg,release-sign-artifacts,sonatype-central-portal-deployment,sonatype-central-snapshots
       SETTINGS: .github/settings.xml
 
     steps:
@@ -82,8 +82,8 @@ jobs:
     - name: Maven deploy
       if: ${{ matrix.maven_deploy && (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request')  }}
       env:
-        OSSRHU: ${{ secrets.OSSRHU }}
-        OSSRHT: ${{ secrets.OSSRHT }}
+        SONATYPE_CENTRAL_PORTAL_REPO_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_REPO_USERNAME }}
+        SONATYPE_CENTRAL_PORTAL_REPO_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_REPO_PASSWORD }}
       run: ./mvnw -U -V -s ${{ env.SETTINGS }} -P${{ env.PROFILES }} ${{ env.MAVEN_PROPS }} deploy
 
     - name: Docker maven build

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
     <scm>
         <url>https://github.com/luminositylabs/luminositylabs-oss</url>
-        <connection>scm:git:https://github.com/luminositylabs/luminositylabs-oss.git</connection>
+        <connection>scm:git:git@github.com:luminositylabs/luminositylabs-oss.git</connection>
         <tag>HEAD</tag>
     </scm>
 
@@ -74,6 +74,7 @@
         <spotbugs.skip>false</spotbugs.skip>
         <!-- Plugin versioning -->
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <directory-maven-plugin-hazendaz.version>1.2.1</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
@@ -495,7 +496,7 @@
                     <configuration>
                         <localCheckout>true</localCheckout>
                         <pushChanges>false</pushChanges>
-                        <releaseProfiles>release-sign-artifacts,sonatype-deployment</releaseProfiles>
+                        <releaseProfiles>release-sign-artifacts,sonatype-central-portal-deployment</releaseProfiles>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -588,6 +589,16 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publishing-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <!-- publishing server id refers to <id> element in <server> section of settings.xml -->
+                        <publishingServerId>sonatype-central-portal</publishingServerId>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -827,17 +838,15 @@
             </build>
         </profile>
         <profile>
-            <id>sonatype-deployment</id>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
+            <id>sonatype-central-portal-deployment</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
- Added central-publishing-maven-plugin to pom.xml
- Replaced sonatype-deployment maven profile with sonatype-central-portal-deployment in pom.xml
- Updated release profiles to use sonatype-central-portal-deployment in pom.xml
- Updated SCM connection URL to use GitHub SSH in pom.xml
- Updated GHA settings.xml to replace ossrh server/profiles with sonatype-central-portal
- Updated GHA main.yml workflow to modify PROFILES env var to replace older OSSRH deployment profiles with newer Sonatype Central profiles
- Updated GHA main.yml workflow to modify env vars in deploy step to replace OSSRH env vars with Sonatype Central env vars