### PR TITLE
branch maintenance Jdk11 - Sonatype Central Portal Publishing (#512)

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -19,12 +19,15 @@
             <id>sonatype-central-snapshots</id>
             <repositories>
                 <repository>
-                    <id>sonatype-central-snapshots</id>
+                    <name>Central Portal Snapshots</name>
+                    <id>central-portal-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
-                    <name>sonatype-central-snapshots</name>
-                    <url>https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/snapshots/</url>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
- Update snapshot repository settings in `settings.xml` to conform to central.sonatype.org documentation


(cherry picked from commit 9b0713d1966484805b7a0a218e4ff9b87459d39d)