### PR TITLE
branch maintenance Jdk17 - Updates (#594)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,14 @@
         <maven-surefire-report-plugin.version>3.5.4</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <maven-wrapper-plugin.version>3.3.4</maven-wrapper-plugin.version>
-        <spotbugs-maven-plugin.version>4.9.4.2</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.9.6.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.19.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>11.0.1</dependency.checkstyle.version>
         <dependency.logback.version>1.5.18</dependency.logback.version>
         <dependency.pmd.version>7.17.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.9.4</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.9.6</dependency.spotbugs.version>
         <dependency.testng.version>7.11.0</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- spotbugs-maven-plugin updated from v4.9.4.2 to v4.9.6.0
- spotbugs updated from v4.9.4 to v4.9.6


(cherry picked from commit a07b62f52edaabf5d726cba976d6004e3154a574)