### PR TITLE
branch maintenance Jdk17 - Updates (#610)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        jdk_version: [17.0.16-zulu, 21.0.8-zulu, 24.0.2-zulu]
+        jdk_version: [17.0.16-zulu, 21.0.8-zulu, 25-zulu]
         include:
           - os: ubuntu-24.04
             jdk_version: 17.0.16-zulu


### PR DESCRIPTION
- updated GHA workflow to replace jdk_version 24.0.2-zulu with 25-zulu



(cherry picked from commit 012a62cf3acbd6c06d382829c819a9bf8eccb1f9)