### PR TITLE
branch maintenance Jdk17 - Updates (#632)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <git-commit-id-maven-plugin.version>9.0.2</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-        <maven-archetype-plugin.version>3.4.0</maven-archetype-plugin.version>
+        <maven-archetype-plugin.version>3.4.1</maven-archetype-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>


### PR DESCRIPTION
- maven-archetype-plugin updated from v3.4.0 to v3.4.1


(cherry picked from commit 6a5ed42adc8926defc4f9b0603075f1c9ad76877)