### PR TITLE
branch maintenance Jdk8 - Updates (#790)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <directory-maven-plugin-hazendaz.version>1.1.3</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
-        <git-commit-id-maven-plugin.version>9.0.2</git-commit-id-maven-plugin.version>
+        <git-commit-id-maven-plugin.version>9.1.0</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.4.1</maven-archetype-plugin.version>


### PR DESCRIPTION
- git-commit-id-maven-plugin updated from v9.0.2 to v9.1.0