### PR TITLE
branch maintenance Jdk17 - Updates (#795)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <directory-maven-plugin-hazendaz.version>1.2.2</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
-        <git-commit-id-maven-plugin.version>9.1.0</git-commit-id-maven-plugin.version>
+        <git-commit-id-maven-plugin.version>10.0.0</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.4.1</maven-archetype-plugin.version>

--- a/testing/nio2-filewalker/pom.xml
+++ b/testing/nio2-filewalker/pom.xml
@@ -20,6 +20,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
- git-commit-id-maven-plugin updated from v9.1.0 to v10.0.0
- added git-commit-id-maven-plugin execution to nio2-filewalker module


(cherry picked from commit b55fdbfe5dc7ff6da06e7ace1e5f4cecc3e1185d)