### PR TITLE
branch maintenance Jdk8 - Compatibility fixes

### DIFF
--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -5,42 +5,55 @@
         <ignoreVersion type="regex">.*[\.-](?i)([M|alpha|beta|rc]).*</ignoreVersion>
     </ignoreVersions>
     <rules>
-        <!-- Pin checkstyle version to pre-v10 (v10 requires Java11) -->
+        <!-- Pin checkstyle version to pre-v10 (v10+ requires Java11) -->
         <rule groupId="com.puppycrawl.tools" artifactId="checkstyle" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">^[1-9]\d+\..*$</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <!-- Pin spotbugs version to pre v4.9.0 (v4.9.0 requires Java11) -->
-        <rule groupId="com.github.spotbugs" artifactId="spotbugs" comparisonMethod="maven">
+
+        <!-- Pin hazendaz directory-maven-plugin version to pre-v1.2  (v1.2+ requires Java11) -->
+        <rule groupId="com.github.hazendaz.maven" artifactId="directory-maven-plugin" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">^4\.(?:9|[1-9]\d+)\..*$</ignoreVersion>
+                <ignoreVersion type="regex">^1\.(?:[2-9]|[1-9]\d+)\..*$</ignoreVersion>
+                <ignoreVersion type="regex">^(?:[2-9]|[1-9]\d+)\..*$</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <rule groupId="com.github.spotbugs" artifactId="spotbugs-annotations" comparisonMethod="maven">
+
+        <!-- Pin git-commit-id-maven-plugin version to pre-v5 (v5+ requires Java11) -->
+        <rule groupId="io.github.git-commit-id" artifactId="git-commit-id-maven-plugin" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">^4\.(?:9|[1-9]\d+)\..*$</ignoreVersion>
+                <ignoreVersion type="regex">^(?:[5-9]|[1-9]\d+)\..*$$</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <!-- Pin testng version to pre 7.6.x (v7.6+ requires Java11) -->
-        <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
-            <ignoreVersions>
-                <ignoreVersion type="regex">^7\.(?:[6-9]|[1-9]\d+)\..*$</ignoreVersion>
-                <ignoreVersion type="regex">^(?:[8-9]|[1-9]\d+)$</ignoreVersion>
-            </ignoreVersions>
-        </rule>
-        <!-- Pin logback version to pre v1.4.0 (v1.4.0+ requires Java11) -->
+
+        <!-- Pin logback version to pre-v1.4 (v1.4+ requires Java11) -->
         <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">^1\.(?:[4-9]|[1-9]\d+)\..*$</ignoreVersion>
                 <ignoreVersion type="regex">^(?:[2-9]|[1-9]\d+)$</ignoreVersion>
             </ignoreVersions>
         </rule>
-        <!-- Pin hazendaz directory-maven-plugin to pre 1.2.0 versions (v1.2.0+ requires Java11) -->
-        <rule groupId="com.github.hazendaz.maven" artifactId="directory-maven-plugin" comparisonMethod="maven">
+
+        <!-- Pin spotbugs version to pre-v4.9 (v4.9+ requires Java11) -->
+        <rule groupId="com.github.spotbugs" artifactId="spotbugs" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">^1\.(?:[2-9]|[1-9]\d+)\..*$</ignoreVersion>
-                <ignoreVersion type="regex">^(?:[2-9]|[1-9]\d+)$</ignoreVersion>
+                <ignoreVersion type="regex">^4\.(?:9|[1-9]\d+)\..*$</ignoreVersion>
+                <ignoreVersion type="regex">^(?:[5-9]|[1-9]\d+)\..*$</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+        <rule groupId="com.github.spotbugs" artifactId="spotbugs-annotations" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">^4\.(?:9|[1-9]\d+)\..*$</ignoreVersion>
+                <ignoreVersion type="regex">^(?:[5-9]|[1-9]\d+)\..*$</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+
+        <!-- Pin testng version to pre-7.6 (v7.6+ requires Java11) -->
+        <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
+            <ignoreVersions>
+                <ignoreVersion type="regex">^7\.(?:[6-9]|[1-9]\d+)\..*$</ignoreVersion>
+                <ignoreVersion type="regex">^(?:[8-9]|[1-9]\d+)\..*$</ignoreVersion>
             </ignoreVersions>
         </rule>
     </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <directory-maven-plugin-hazendaz.version>1.1.3</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
-        <git-commit-id-maven-plugin.version>9.1.0</git-commit-id-maven-plugin.version>
+        <git-commit-id-maven-plugin.version>4.9.9</git-commit-id-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.4.1</maven-archetype-plugin.version>

--- a/testing/nio2-filewalker/pom.xml
+++ b/testing/nio2-filewalker/pom.xml
@@ -20,6 +20,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
- git-commit-id-maven-plugin reverted from v10.0.0 to v4.9.9
- added git-commit-id-maven-plugin ignore rules to maven-version-rules.xml to ignore all versions later than v4.9.9
- added git-commit-id-maven-plugin execution to nio2-filewalker module