### PR TITLE
branch maintenance Jdk17 - Updates (#839)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <maven-ear-plugin.version>3.4.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
@@ -106,15 +106,15 @@
         <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.5.5</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.5.6</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
         <maven-wrapper-plugin.version>3.3.4</maven-wrapper-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.3</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>12.3.1</dependency.checkstyle.version>
-        <dependency.logback.version>1.5.32</dependency.logback.version>
+        <dependency.logback.version>1.5.33</dependency.logback.version>
         <dependency.pmd.version>7.24.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.18</dependency.slf4j.version>
         <dependency.spotbugs.version>4.9.8</dependency.spotbugs.version>


### PR DESCRIPTION
- maven-failsafe-plugin updated from v3.5.5 to v3.5.6
- maven-surefire-plugin updated from v3.5.5 to v3.5.6
- maven-surefire-report-plugin updated from v3.5.5 to v3.5.6
- logback updated from v1.5.32 to v1.5.33


(cherry picked from commit 2edde616963c8437e5914f0579fe8aeb39ba6ce5)