### PR TITLE
branch maintenance Jdk21 - Updates (#868)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,14 @@
         <maven-surefire-report-plugin.version>3.5.6</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
         <maven-wrapper-plugin.version>3.3.4</maven-wrapper-plugin.version>
-        <spotbugs-maven-plugin.version>4.9.8.4</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>13.5.0</dependency.checkstyle.version>
         <dependency.logback.version>1.5.34</dependency.logback.version>
         <dependency.pmd.version>7.25.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.18</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.10.1</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.10.2</dependency.spotbugs.version>
         <dependency.testng.version>7.12.0</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- spotbugs-maven-plugin updated from v4.9.8.4 to v4.10.2.0
- spotbugs updated from v4.10.1 to v4.10.2


(cherry picked from commit 05707c251ebf42b52519240c9bbd1041411cce99)