### PR TITLE
branch maintenance Jdk21 - Updates (#879)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
-        <directory-maven-plugin-hazendaz.version>1.2.2</directory-maven-plugin-hazendaz.version>
+        <directory-maven-plugin-hazendaz.version>1.3.0</directory-maven-plugin-hazendaz.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
         <git-commit-id-maven-plugin.version>10.0.0</git-commit-id-maven-plugin.version>
@@ -114,7 +114,7 @@
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>13.6.0</dependency.checkstyle.version>
-        <dependency.logback.version>1.5.34</dependency.logback.version>
+        <dependency.logback.version>1.5.35</dependency.logback.version>
         <dependency.pmd.version>7.25.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.18</dependency.slf4j.version>
         <dependency.spotbugs.version>4.10.2</dependency.spotbugs.version>


### PR DESCRIPTION
- directory-maven-plugin-hazendaz updated from v1.2.2 to v1.3.0


(cherry picked from commit 86f359cf338491469185924498c12b0acd9189f9)