### PR TITLE
branch maintenance Jdk11 - Updates (#900)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,14 @@
         <maven-surefire-report-plugin.version>3.5.6</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
         <maven-wrapper-plugin.version>3.3.4</maven-wrapper-plugin.version>
-        <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>10.26.1</dependency.checkstyle.version>
         <dependency.logback.version>1.5.38</dependency.logback.version>
         <dependency.pmd.version>7.26.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.18</dependency.slf4j.version>
-        <dependency.spotbugs.version>4.10.2</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.10.3</dependency.spotbugs.version>
         <dependency.testng.version>7.12.0</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- spotbugs updated from v4.10.2 to v4.10.3
- spotbugs-maven-plugin updated from v4.10.2.0 to v4.10.3.0


(cherry picked from commit 8c51401df1af101c630734c51df08c69837d4cba)