### PR TITLE
branch maintenance Jdk21  - Updates (#913)

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -65,7 +65,7 @@
         <module name="JavadocMethod"/>
         <module name="JavadocType"/>
         <module name="JavadocVariable"/>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>13.8.0</dependency.checkstyle.version>
+        <dependency.checkstyle.version>13.9.0</dependency.checkstyle.version>
         <dependency.logback.version>1.6.0</dependency.logback.version>
         <dependency.pmd.version>7.26.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.18</dependency.slf4j.version>

--- a/testing/checkstyle.xml
+++ b/testing/checkstyle.xml
@@ -65,7 +65,7 @@
         <module name="JavadocMethod"/>
         <module name="JavadocType"/>
         <module name="JavadocVariable"/>
-        <module name="JavadocStyle"/>
+        <module name="SummaryJavadoc"/>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->


### PR DESCRIPTION
- checkstyle updated from v13.8.0 to v13.9.0
- migrated checkstyle.xml from using now-unsupported JavadocStyle module to SummaryJavadoc


(cherry picked from commit 244386184116307f725d101976357b245f68639c)