### PR TITLE
branch maintenance Jdk21 - Updates (#926)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         jdk_version: [21.0.12-zulu,25.0.4-zulu]
         include:
           - os: ubuntu-24.04

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
         <spotbugs-maven-plugin.version>4.10.3.0</spotbugs-maven-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>13.9.0</dependency.checkstyle.version>
-        <dependency.logback.version>1.6.1</dependency.logback.version>
+        <dependency.checkstyle.version>13.10.0</dependency.checkstyle.version>
+        <dependency.logback.version>1.6.2</dependency.logback.version>
         <dependency.pmd.version>7.26.0</dependency.pmd.version>
         <dependency.slf4j.version>2.0.18</dependency.slf4j.version>
         <dependency.spotbugs.version>4.10.3</dependency.spotbugs.version>


### PR DESCRIPTION
- CI GHA runner os updated from ubuntu-24.04 to ubuntu-26.04
- checkstyle updated from v3.9.0 to v3.10.0
- logback updated from v1.6.1 to v1.6.2


(cherry picked from commit 9a3e183464b945118545cf76d07dfe57ba063071)