### PR TITLE
branch maintenance Jdk8 - Updates (#926)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         jdk_version: [8.0.502-zulu, 11.0.32-zulu, 17.0.20-zulu, 21.0.12-zulu, 25.0.4-zulu]
         include:
           - os: ubuntu-24.04


### PR DESCRIPTION
- CI GHA runner os updated from ubuntu-24.04 to ubuntu-26.04