### PR TITLE
branch maintenance Jdk21 - ci fix GHA strategy matrix include os ubuntu-26.04 (#935)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-26.04]
         jdk_version: [21.0.12-zulu,25.0.4-zulu]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             jdk_version: 21.0.12-zulu
             zulu_version: 21.52.15
             maven_deploy: true


### PR DESCRIPTION
(cherry picked from commit a756ae2fcd455adabb11d596efce8b9f938281e8)