### PR TITLE
branch maintenance Jdk17 - ci fix GHA strategy matrix include os ubuntu-26.04 (#935)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         jdk_version: [17.0.20-zulu, 21.0.12-zulu, 25.0.4-zulu]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             jdk_version: 17.0.20-zulu
             zulu_version: 17.68.17
             maven_deploy: true


### PR DESCRIPTION
(cherry picked from commit a756ae2fcd455adabb11d596efce8b9f938281e8)